### PR TITLE
Add more sophisticated logging

### DIFF
--- a/ProgrammingTask/client.py
+++ b/ProgrammingTask/client.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import pygame
 
 from network import Network
+from config import LOG_LEVEL
 
 pygame.font.init()
 width = 1000
@@ -14,7 +15,7 @@ pygame.display.set_caption("Player")
 
 FPS_LIMIT = 60
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger(__name__)
 
 

--- a/ProgrammingTask/client.py
+++ b/ProgrammingTask/client.py
@@ -1,14 +1,22 @@
-import pygame
-from network import Network
 import pickle
-pygame.font.init()
+import logging
+from datetime import datetime
 
+import pygame
+
+from network import Network
+
+pygame.font.init()
 width = 1000
 height = 700
 win = pygame.display.set_mode((width,height))
 pygame.display.set_caption("Player")
 
 FPS_LIMIT = 60
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 class Button:
     def __init__(self, text, x, y, color):
@@ -106,7 +114,7 @@ def main():
     n = Network()
 
     player = int(n.getPlayerId())
-    print("You are a player: ", player)
+    logger.info(f"You are a player: {player}")
 
     clock = pygame.time.Clock()
 
@@ -117,7 +125,7 @@ def main():
             game = n.send("get")
         except:
             run = False
-            print("No game detected")
+            logger.warning("No game detected")
             break
 
         if game.allWent():
@@ -127,7 +135,7 @@ def main():
                 game = n.send("reset")
             except:
                 run = False
-                print("Couldn't get game")
+                logger.warning("Couldn't get game")
                 break
 
             # tie:    [1, 0, 0, 0]
@@ -136,7 +144,12 @@ def main():
             # p3 Win: [0, 0, 0, 1]
 
             font = pygame.font.SysFont("comicsans", 90)
+            benchmark_start = datetime.now()
             outcome_text = game.outcome_for_player(player)
+            benchmark_duration = datetime.now() - benchmark_start
+            microseconds = benchmark_duration.microseconds
+
+            logger.info(f'calculated player outcome in {microseconds} us')
             outcome_font = font.render(outcome_text, 1, (255,0,0))
 
             win.blit(outcome_font, (width/2 - outcome_font.get_width()/2, height/2 - outcome_font.get_height()/2))

--- a/ProgrammingTask/client.py
+++ b/ProgrammingTask/client.py
@@ -65,7 +65,7 @@ def redrawWindow(win, game, player):
                 text1 = font.render("Locked In", 1, (0, 0, 0))
             else:
                 text1 = font.render("Waiting...", 1, (0, 0, 0))
-            
+
             if game.p2Went and player == 1:
                 text2 = font.render(move2, 1, (0,0,0))
             elif game.p2Went:
@@ -99,10 +99,12 @@ def redrawWindow(win, game, player):
     pygame.display.update()
 
 btns = [Button("Rock", 200, 500, (0,0,0)), Button("Scissors", 400, 500, (255,0,0)), Button("Paper", 600, 500, (0,255,0))]
+
+
 def main():
     run = True
     n = Network()
-    
+
     player = int(n.getPlayerId())
     print("You are a player: ", player)
 
@@ -134,14 +136,10 @@ def main():
             # p3 Win: [0, 0, 0, 1]
 
             font = pygame.font.SysFont("comicsans", 90)
-            if (game.winner() == [0, 1, 0, 0] and player == 0) or (game.winner() == [0, 0, 1, 0] and player == 1) or (game.winner() == [0,0,0,1] and player == 2) or (game.winner() == [0, 1, 1, 0] and (player == 0 or player == 1)) or (game.winner() == [0, 1, 0, 1] and (player == 0 or player == 2)) or (game.winner() == [0, 0, 1, 1] and (player == 1 or player == 2)):
-                text = font.render("You Won!", 1, (255,0,0))
-            elif game.winner() == [1, 0, 0, 0]:
-                text = font.render("Tie Game!", 1, (255,0,0))
-            else:
-                text = font.render("You Lost...", 1, (255, 0, 0))
+            outcome_text = game.outcome_for_player(player)
+            outcome_font = font.render(outcome_text, 1, (255,0,0))
 
-            win.blit(text, (width/2 - text.get_width()/2, height/2 - text.get_height()/2))
+            win.blit(outcome_font, (width/2 - outcome_font.get_width()/2, height/2 - outcome_font.get_height()/2))
             pygame.display.update()
             pygame.time.delay(2000)
 

--- a/ProgrammingTask/client.py
+++ b/ProgrammingTask/client.py
@@ -199,5 +199,7 @@ def menu_screen():
 
     main()
 
-while True:
-    menu_screen()
+
+if __name__ == '__main__':
+    while True:
+        menu_screen()

--- a/ProgrammingTask/config.py
+++ b/ProgrammingTask/config.py
@@ -3,5 +3,5 @@
 Provide common configuration point between game modules and remove duplication.
 """
 
-SERVER_ADDRESS = "51.195.91.234"
+SERVER_ADDRESS = "localhost"
 SERVER_PORT = 5555

--- a/ProgrammingTask/config.py
+++ b/ProgrammingTask/config.py
@@ -2,6 +2,8 @@
 
 Provide common configuration point between game modules and remove duplication.
 """
+import logging
 
 SERVER_ADDRESS = "localhost"
 SERVER_PORT = 5555
+LOG_LEVEL = logging.INFO

--- a/ProgrammingTask/game.py
+++ b/ProgrammingTask/game.py
@@ -30,6 +30,21 @@ class Game:
     def allWent(self):
         return self.p1Went and self.p2Went and self.p3Went
 
+    def outcome_for_player(self, player):
+        if (
+            (self.winner() == [0, 1, 0, 0] and player == 0)
+            or (self.winner() == [0, 0, 1, 0] and player == 1)
+            or (self.winner() == [0, 0, 0, 1] and player == 2)
+            or (self.winner() == [0, 1, 1, 0] and (player == 0 or player == 1))
+            or (self.winner() == [0, 1, 0, 1] and (player == 0 or player == 2))
+            or (self.winner() == [0, 0, 1, 1] and (player == 1 or player == 2))
+        ):
+            return "You Won!"
+        elif self.winner() == [1, 0, 0, 0]:
+            return "Tie Game!"
+        else:
+            return "You Lost..."
+
     def winner(self):
         p1 = self.moves[0].upper()[0] # Win: [0, 1, 0, 0]
         p2 = self.moves[1].upper()[0] # Win: [0, 0, 1, 0]

--- a/ProgrammingTask/network.py
+++ b/ProgrammingTask/network.py
@@ -5,7 +5,11 @@ Functionality for creating socket connections for clients.
 
 import socket
 import pickle
+import logging
+
 from config import SERVER_ADDRESS, SERVER_PORT
+
+logger = logging.getLogger(__name__)
 
 
 class Network:
@@ -23,12 +27,12 @@ class Network:
         try:
             self.client.connect(self.addr)
             return self.client.recv(2048).decode()
-        except InterruptedError as e:
-            print(e)
+        except InterruptedError:
+            logger.exception('error connecting the client')
 
     def send(self, data):
         try:
             self.client.send(str.encode(data))
             return pickle.loads(self.client.recv(2048*2))
-        except (OSError, pickle.UnpicklingError) as e:
-            print(e)
+        except (OSError, pickle.UnpicklingError):
+            logger.exception('error sending data')

--- a/ProgrammingTask/server.py
+++ b/ProgrammingTask/server.py
@@ -2,19 +2,25 @@ import socket
 import pickle
 from _thread import start_new_thread
 import sys
-from game import Game
+from datetime import datetime
+import logging
 
+from game import Game
 from config import SERVER_PORT, SERVER_ADDRESS
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
 try:
     s.bind((SERVER_ADDRESS, SERVER_PORT))
 except OSError as e:
-    print("socket error", str(e))
+    logger.exception("socket error")
 
 s.listen(3) #3 clients can connect
-print("Waiting for a connection, Server Started")
+logger.info("Waiting for a connection, Server Started")
 
 connected = set()
 games = {}
@@ -32,53 +38,58 @@ def threaded_client(conn, playerId, gameId):
                 game = games[gameId]
 
                 if not data:
-                    print("No data.")
+                    logger.warning("No data.")
                     break
                 else:
                     if data == "reset":
                         game.resetWent()
                     elif data != "get":
-                        print("Got a play:", playerId, data)
+                        logger.info(f"Got a play: {playerId} {data}")
+                        benchmark_start = datetime.now()
                         game.play(playerId, data)
+
+                        elapsed = datetime.now() - benchmark_start
+
+                        logger.info(f'calculated next game state in {elapsed.microseconds} us')
 
                     conn.sendall(pickle.dumps(game))
             else:
-                print("Invalid game id", gameId, ", list of games:", games)
+                logger.warning("Invalid game id: {gameId}, list of games: {games}")
                 break
         except ConnectionResetError:
             # This happens when client cuts the connection.
-            print(f"{playerId}: connection reset")
+            logger.warning(f"{playerId}: connection reset")
             break
         except InterruptedError as e:
-            print(e)
+            logger.warning(e)
             break
 
-    print(f"Client {playerId} disconnected, terminating connection")
+    logger.info(f"Client {playerId} disconnected, terminating connection")
     try:
         del games[gameId]
-        print("Closing Game", gameId)
-    except NameError as e:
-        print(e)
+        logger.info(f"Closing Game {gameId}")
+    except NameError:
+        logger.exception('error closing game')
+
     idCount -= 1
     conn.close()
 
 while True:
     conn, addr = s.accept()
-    print("Connected to:", addr)
+    logger.info(f"Connected to: {addr}")
 
     idCount += 1
     p = 0
     gameId = (idCount - 1)//3
     if idCount % 3 == 1:
         games[gameId] = Game(gameId)
-        print("Creating a new game...")
+        logger.info("Creating a new game...")
     elif idCount % 3 == 2:
-        print("Player 2 connected")
+        logger.info("Player 2 connected")
         p = 1
     elif idCount % 3 == 0:
-        print("Player 3 connected, starting game")
+        logger.info("Player 3 connected, starting game")
         games[gameId].ready = True
         p = 2
 
     start_new_thread(threaded_client, (conn, p, gameId))
-

--- a/ProgrammingTask/server.py
+++ b/ProgrammingTask/server.py
@@ -6,10 +6,10 @@ from datetime import datetime
 import logging
 
 from game import Game
-from config import SERVER_PORT, SERVER_ADDRESS
+from config import SERVER_PORT, SERVER_ADDRESS, LOG_LEVEL
 
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger(__name__)
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/ProgrammingTask/server.py
+++ b/ProgrammingTask/server.py
@@ -14,12 +14,8 @@ logger = logging.getLogger(__name__)
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-try:
-    s.bind((SERVER_ADDRESS, SERVER_PORT))
-except OSError as e:
-    logger.exception("socket error")
-
-s.listen(3) #3 clients can connect
+s.bind((SERVER_ADDRESS, SERVER_PORT))
+s.listen(3) # 3 clients can connect
 logger.info("Waiting for a connection, Server Started")
 
 connected = set()
@@ -54,7 +50,7 @@ def threaded_client(conn, playerId, gameId):
 
                     conn.sendall(pickle.dumps(game))
             else:
-                logger.warning("Invalid game id: {gameId}, list of games: {games}")
+                logger.info(f"{gameId} is missing, exiting game...")
                 break
         except ConnectionResetError:
             # This happens when client cuts the connection.
@@ -65,14 +61,16 @@ def threaded_client(conn, playerId, gameId):
             break
 
     logger.info(f"Client {playerId} disconnected, terminating connection")
-    try:
+
+    if gameId in games:
         del games[gameId]
-        logger.info(f"Closing Game {gameId}")
-    except NameError:
-        logger.exception('error closing game')
+        logger.info(f'deleted game {gameId}')
+    else:
+        logger.info(f"didn't terminate game {gameId} because it was already deleted")
 
     idCount -= 1
     conn.close()
+
 
 while True:
     conn, addr = s.accept()

--- a/ProgrammingTask/server.py
+++ b/ProgrammingTask/server.py
@@ -12,82 +12,90 @@ from config import SERVER_PORT, SERVER_ADDRESS, LOG_LEVEL
 logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger(__name__)
 
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-s.bind((SERVER_ADDRESS, SERVER_PORT))
-s.listen(3) # 3 clients can connect
-logger.info("Waiting for a connection, Server Started")
+class RPSServer:
+    def __init__(self):
+        self.games = {}
+        self.idCount = 0
 
-connected = set()
-games = {}
-idCount = 0
+    def player_client(self, conn, playerId, gameId):
+        conn.send(str.encode(str(playerId)))
 
-def threaded_client(conn, playerId, gameId):
-    global idCount
-    conn.send(str.encode(str(playerId)))
+        while True:
+            try:
+                data = conn.recv(2048*2).decode('utf-8')
 
-    while True:
-        try:
-            data = conn.recv(2048*2).decode('utf-8')
+                if gameId in self.games:
+                    game = self.games[gameId]
 
-            if gameId in games:
-                game = games[gameId]
+                    if not data:
+                        logger.warning("No data.")
+                        break
+                    else:
+                        if data == "reset":
+                            game.resetWent()
+                        elif data != "get":
+                            logger.info(f"Got a play: {playerId} {data}")
+                            benchmark_start = datetime.now()
+                            game.play(playerId, data)
 
-                if not data:
-                    logger.warning("No data.")
-                    break
+                            elapsed = datetime.now() - benchmark_start
+
+                            logger.info(f'calculated next game state in {elapsed.microseconds} us')
+
+                        conn.sendall(pickle.dumps(game))
                 else:
-                    if data == "reset":
-                        game.resetWent()
-                    elif data != "get":
-                        logger.info(f"Got a play: {playerId} {data}")
-                        benchmark_start = datetime.now()
-                        game.play(playerId, data)
-
-                        elapsed = datetime.now() - benchmark_start
-
-                        logger.info(f'calculated next game state in {elapsed.microseconds} us')
-
-                    conn.sendall(pickle.dumps(game))
-            else:
-                logger.info(f"{gameId} is missing, exiting game...")
+                    logger.info(f"{gameId} is missing, exiting game...")
+                    break
+            except ConnectionResetError:
+                # This happens when client cuts the connection.
+                logger.warning(f"{playerId}: connection reset")
                 break
-        except ConnectionResetError:
-            # This happens when client cuts the connection.
-            logger.warning(f"{playerId}: connection reset")
-            break
-        except InterruptedError as e:
-            logger.warning(e)
-            break
+            except InterruptedError as e:
+                logger.warning(e)
+                break
 
-    logger.info(f"Client {playerId} disconnected, terminating connection")
+        logger.info(f"Client {playerId} disconnected, terminating connection")
 
-    if gameId in games:
-        del games[gameId]
-        logger.info(f'deleted game {gameId}')
-    else:
-        logger.info(f"didn't terminate game {gameId} because it was already deleted")
+        if gameId in self.games:
+            del self.games[gameId]
+            logger.info(f'deleted game {gameId}')
+        else:
+            logger.info(f"didn't terminate game {gameId} because it was already deleted")
 
-    idCount -= 1
-    conn.close()
+        self.idCount -= 1
+        conn.close()
+
+    def run(self):
+        logger.info("Waiting for a connection, Server Started")
+
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        s.bind((SERVER_ADDRESS, SERVER_PORT))
+        s.listen(3)  # 3 clients can connect
+
+        while True:
+            conn, addr = s.accept()
+            logger.info(f"Connected to: {addr}")
+
+            self.idCount += 1
+            p = 0
+            gameId = (self.idCount - 1)//3
+            if self.idCount % 3 == 1:
+                self.games[gameId] = Game(gameId)
+                logger.info("Creating a new game...")
+            elif self.idCount % 3 == 2:
+                logger.info("Player 2 connected")
+                p = 1
+            elif self.idCount % 3 == 0:
+                logger.info("Player 3 connected, starting game")
+                self.games[gameId].ready = True
+                p = 2
+
+            start_new_thread(self.player_client, (conn, p, gameId))
 
 
-while True:
-    conn, addr = s.accept()
-    logger.info(f"Connected to: {addr}")
+if __name__ == '__main__':
+    server = RPSServer()
 
-    idCount += 1
-    p = 0
-    gameId = (idCount - 1)//3
-    if idCount % 3 == 1:
-        games[gameId] = Game(gameId)
-        logger.info("Creating a new game...")
-    elif idCount % 3 == 2:
-        logger.info("Player 2 connected")
-        p = 1
-    elif idCount % 3 == 0:
-        logger.info("Player 3 connected, starting game")
-        games[gameId].ready = True
-        p = 2
-
-    start_new_thread(threaded_client, (conn, p, gameId))
+    server.run()


### PR DESCRIPTION
* Use python built-in logging module instead of print statements

* Log performance for two operations: 1. the next game state calculation in server 2. winner calculation in client

For next week we can analyze how the performance changes with high number of players (or just throttle the server/client if that's easier).

Please note that server.py diff is mostly moving code around.